### PR TITLE
Increases subprocess buffers of npm and esy

### DIFF
--- a/src/lib/esy.ts
+++ b/src/lib/esy.ts
@@ -35,6 +35,7 @@ async function subcommand(
       {
         cwd,
         env,
+	maxBuffer: 1024 * 500
       },
       (error: Error, stdout: string, stderr: string) => {
         if (error) {

--- a/src/lib/npm-client.ts
+++ b/src/lib/npm-client.ts
@@ -8,7 +8,7 @@ export async function publish(
   return new Promise(function (resolve, reject) {
     cp.exec(
       `npm publish --registry ${registryUrl} ${tarballPath}`,
-      {},
+      {maxBuffer: 5000 * 1024},
       (error: Error, stdout, stderr) => {
         if (error) {
           reject(error);
@@ -24,7 +24,7 @@ export async function pack(pkgPath: path): Promise<ProcessOutput> {
   return new Promise(function (resolve, reject) {
     cp.exec(
       "npm pack",
-      { cwd: pkgPath },
+      { cwd: pkgPath, maxBuffer: 5000 * 1024,},
       (error: cp.ExecException, stdout: string, stderr: string) => {
         if (error) {
           reject(error);


### PR DESCRIPTION
Because on Windows, powershell would kill saying buffers are not big enough